### PR TITLE
Fix: Prevent logged-in users from accessing the login page

### DIFF
--- a/vistas/plantilla.php
+++ b/vistas/plantilla.php
@@ -64,6 +64,12 @@ if ($rutaActual === 'salir') {
     exit();
 }
 
+// Redirigir si el usuario logueado intenta acceder al login
+if (isset($_SESSION["iniciarSesion"]) && $_SESSION["iniciarSesion"] === "ok" && $rutaActual === 'login') {
+    header('Location: inicio');
+    exit();
+}
+
 // Verificar sesión para todas las demás rutas
 if (isset($_SESSION["iniciarSesion"]) && $_SESSION["iniciarSesion"] == "ok") {
 ?>
@@ -77,7 +83,7 @@ if (isset($_SESSION["iniciarSesion"]) && $_SESSION["iniciarSesion"] == "ok") {
     $rutasPermitidas = [
       "inicio", "usuarios", "trabajadores", "elFinder", "operadores",
       "origenes", "destinos", "marcas", "unidades", "pasajeros",
-      "reportes", "reportesp", "salir", "login"
+      "reportes", "reportesp", "salir"
     ];
 
     $archivo = in_array($ruta, $rutasPermitidas) ? "modulos/$ruta.php" : "modulos/404.php";


### PR DESCRIPTION
This change adds a redirection mechanism to prevent users who are already logged in from navigating back to the login page. If a logged-in user attempts to access the 'login' route, they will be redirected to the 'inicio' (home) page.

This is achieved by:
- Adding a check at the beginning of the main template that redirects logged-in users away from the login page using a PHP header.
- Removing 'login' from the array of permitted routes for logged-in users as a defensive measure.